### PR TITLE
feat: 新增标签页打开位置配置选项

### DIFF
--- a/chromium/_locales/zh_CN/messages.json
+++ b/chromium/_locales/zh_CN/messages.json
@@ -73,5 +73,14 @@
 	},
 	"fileInputFailed" : {
 		"message" : "配置导入失败"
-	}
+	},
+    "tabOpenPos" : {
+        "message" : "新标签页打开位置："
+    },
+    "tabOpenPosNextLabel" : {
+        "message" : "紧邻当前标签页"
+    },
+    "tabOpenPosEndLabel" : {
+        "message" : "在标签页末尾（类Vivaldi）"
+    }
 }

--- a/chromium/common.js
+++ b/chromium/common.js
@@ -8,6 +8,7 @@ function _getDefault() {
 		showNotice: true,
 		keyCode: "Escape",
 		openLinksOpenType: 1,
+		tabOpenPos: "end",
 
 		effect_text : 0,
 		open_type : [1, 1, 0, 1],

--- a/chromium/eventpage.js
+++ b/chromium/eventpage.js
@@ -20,6 +20,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
               }
             }
           }
+          sendResponse({status: 'ok'});
         });
       } else { // 'end'
         chrome.tabs.query({currentWindow: true}, tabs => {
@@ -27,6 +28,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             for (const tab of tabs.reverse()) {
               if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
                 chrome.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: tab.id, active: message['active']});
+                sendResponse({status: 'ok'});
                 return;
               }
             }
@@ -44,20 +46,25 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     chrome.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active']});
                   }
                 }
+                sendResponse({status: 'ok'});
                 return;
               }
             }
           }
+          sendResponse({status: 'ok'});
         });
       }
     });
+    return true; // Indicates async response
   } else if (message['flag'] == 'download') {
     chrome.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
     }, function (downloadId) {
       console.log(downloadId);
+      sendResponse({status: 'ok'});
     });
+    return true; // Indicates async response
   }
   sendResponse({status: 'ok'});
 });

--- a/chromium/eventpage.js
+++ b/chromium/eventpage.js
@@ -1,40 +1,62 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message['flag'] == 'openTable') {
-    chrome.tabs.query({currentWindow: true}, tabs => {
-      // console.log(tabs)
-      // console.log(message);
-      if (typeof message['url'] == "string") {
-        for (const tab of tabs.reverse()) {
-          if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
-            chrome.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: tab.id, active: message['active']});
-            return;
-          }
-        }
-      } else {
-        for (const tab of tabs.reverse()) {
-          if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
-            for (const i in message['url']){
-              if (message['active'] == true){
-                if (i == 0){
-                  chrome.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active'] });
+    chrome.storage.sync.get({superDrag: _getDefault()}, function (result) {
+      const settings = result.superDrag;
+      if (settings.tabOpenPos === 'next') {
+        chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+          const activeTab = tabs[0];
+          if (typeof message['url'] == "string") {
+            chrome.tabs.create({index: activeTab.index + 1, url: message['url'], openerTabId: activeTab.id, active: message['active']});
+          } else {
+            for (var i in message['url']) {
+              if (message['active'] == true) {
+                if (i == 0) {
+                  chrome.tabs.create({index: activeTab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: activeTab.id, active: message['active']});
                 } else {
-                  chrome.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: false });
+                  chrome.tabs.create({index: activeTab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: activeTab.id, active: false});
                 }
               } else {
-                chrome.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active'] });
+                chrome.tabs.create({index: activeTab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: activeTab.id, active: message['active']});
               }
             }
-            return;
           }
-        }
+        });
+      } else { // 'end'
+        chrome.tabs.query({currentWindow: true}, tabs => {
+          if (typeof message['url'] == "string") {
+            for (const tab of tabs.reverse()) {
+              if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
+                chrome.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: tab.id, active: message['active']});
+                return;
+              }
+            }
+          } else {
+            for (const tab of tabs.reverse()) {
+              if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
+                for (const i in message['url']) {
+                  if (message['active'] == true) {
+                    if (i == 0) {
+                      chrome.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active']});
+                    } else {
+                      chrome.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: false});
+                    }
+                  } else {
+                    chrome.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active']});
+                  }
+                }
+                return;
+              }
+            }
+          }
+        });
       }
     });
   } else if (message['flag'] == 'download') {
     chrome.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
-    },function(downloadId) {
-        console.log(downloadId);
+    }, function (downloadId) {
+      console.log(downloadId);
     });
   }
   sendResponse({status: 'ok'});

--- a/chromium/options.html
+++ b/chromium/options.html
@@ -36,6 +36,18 @@
     </div>
     <hr>
     <div>
+        <span id="tabOpenPos" style="font-size: 15px"></span>
+        <label style="font-size: 15px; margin-left: 10px;">
+            <input type="radio" id="tabOpenPosNext" name="tabOpenPos" value="next">
+            <span id="tabOpenPosNextLabel"></span>
+        </label>
+        <label style="font-size: 15px; margin-left: 10px;">
+            <input type="radio" id="tabOpenPosEnd" name="tabOpenPos" value="end">
+            <span id="tabOpenPosEndLabel"></span>
+        </label>
+    </div>
+    <hr>
+    <div>
         <span id="openLinksDesc" style="font-size: 15px"></span>
         <input id="keyCode" type="text" placeholder="event.key" style="width: 60px">
         <span id="openLinksDesc2" style="font-size: 15px"></span>

--- a/chromium/options.html
+++ b/chromium/options.html
@@ -37,14 +37,7 @@
     <hr>
     <div>
         <span id="tabOpenPos" style="font-size: 15px"></span>
-        <label style="font-size: 15px; margin-left: 10px;">
-            <input type="radio" id="tabOpenPosNext" name="tabOpenPos" value="next">
-            <span id="tabOpenPosNextLabel"></span>
-        </label>
-        <label style="font-size: 15px; margin-left: 10px;">
-            <input type="radio" id="tabOpenPosEnd" name="tabOpenPos" value="end">
-            <span id="tabOpenPosEndLabel"></span>
-        </label>
+        <select id="tabOpenPosSelect" style="font-size: 15px; margin-left: 10px;"></select>
     </div>
     <hr>
     <div>

--- a/chromium/options.js
+++ b/chromium/options.js
@@ -168,6 +168,16 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
 
             reader.readAsText(file);
         }, false);
+    document.getElementById("tabOpenPosNext").addEventListener(
+        "change", function () {
+            superDrag.superDrag.tabOpenPos = this.value;
+            _save(superDrag.superDrag);
+        }, false);
+    document.getElementById("tabOpenPosEnd").addEventListener(
+        "change", function () {
+            superDrag.superDrag.tabOpenPos = this.value;
+            _save(superDrag.superDrag);
+        }, false);
 
     document.getElementById('timeout').value = superDrag.superDrag.timeout;
     document.getElementById('keyCode').value = superDrag.superDrag.keyCode;
@@ -208,6 +218,14 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     document.getElementById('searchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
     document.getElementById('linkSearchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
     document.getElementById('imgSearchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
+    document.getElementById('tabOpenPos').innerHTML = chrome.i18n.getMessage('tabOpenPos');
+    document.getElementById('tabOpenPosNextLabel').innerHTML = chrome.i18n.getMessage('tabOpenPosNext');
+    document.getElementById('tabOpenPosEndLabel').innerHTML = chrome.i18n.getMessage('tabOpenPosEnd');
+    if (superDrag.superDrag.tabOpenPos === 'next') {
+        document.getElementById('tabOpenPosNext').checked = true;
+    } else {
+        document.getElementById('tabOpenPosEnd').checked = true;
+    }
     document.getElementById("enableAlt").checked = superDrag.superDrag.enableAlt;
     document.getElementById("firstEvent").checked = superDrag.superDrag.firstEvent;
     document.getElementById("saveAs").checked = superDrag.superDrag.saveAs;

--- a/chromium/options.js
+++ b/chromium/options.js
@@ -168,12 +168,7 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
 
             reader.readAsText(file);
         }, false);
-    document.getElementById("tabOpenPosNext").addEventListener(
-        "change", function () {
-            superDrag.superDrag.tabOpenPos = this.value;
-            _save(superDrag.superDrag);
-        }, false);
-    document.getElementById("tabOpenPosEnd").addEventListener(
+    document.getElementById("tabOpenPosSelect").addEventListener(
         "change", function () {
             superDrag.superDrag.tabOpenPos = this.value;
             _save(superDrag.superDrag);
@@ -219,13 +214,14 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     document.getElementById('linkSearchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
     document.getElementById('imgSearchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
     document.getElementById('tabOpenPos').innerHTML = chrome.i18n.getMessage('tabOpenPos');
-    document.getElementById('tabOpenPosNextLabel').innerHTML = chrome.i18n.getMessage('tabOpenPosNext');
-    document.getElementById('tabOpenPosEndLabel').innerHTML = chrome.i18n.getMessage('tabOpenPosEnd');
-    if (superDrag.superDrag.tabOpenPos === 'next') {
-        document.getElementById('tabOpenPosNext').checked = true;
-    } else {
-        document.getElementById('tabOpenPosEnd').checked = true;
+    
+    // Initialize tab open position dropdown
+    const tabOpenPosSelect = document.getElementById("tabOpenPosSelect");
+    if (!tabOpenPosSelect.options.length) {
+        tabOpenPosSelect.add(new Option(chrome.i18n.getMessage('tabOpenPosNext'), 'next', false));
+        tabOpenPosSelect.add(new Option(chrome.i18n.getMessage('tabOpenPosEnd'), 'end', false));
     }
+    tabOpenPosSelect.value = superDrag.superDrag.tabOpenPos;
     document.getElementById("enableAlt").checked = superDrag.superDrag.enableAlt;
     document.getElementById("firstEvent").checked = superDrag.superDrag.firstEvent;
     document.getElementById("saveAs").checked = superDrag.superDrag.saveAs;

--- a/firefox/_locales/zh_CN/messages.json
+++ b/firefox/_locales/zh_CN/messages.json
@@ -73,5 +73,14 @@
 	},
 	"fileInputFailed" : {
 		"message" : "配置导入失败"
-	}
+	},
+    "tabOpenPos" : {
+        "message" : "新标签页打开位置："
+    },
+    "tabOpenPosNextLabel" : {
+        "message" : "紧邻当前标签页"
+    },
+    "tabOpenPosEndLabel" : {
+        "message" : "在标签页末尾（类Vivaldi）"
+    }
 }

--- a/firefox/background-script.js
+++ b/firefox/background-script.js
@@ -1,42 +1,64 @@
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message['flag'] == 'openTable') {
-    browser.tabs.query({currentWindow: true}, tabs => {
-      // console.log(tabs)
-      // console.log(message);
-      let currentTab = tabs.find(tab => tab.active === true);
-      let showTabs = tabs.filter(tab => tab.url !== 'about:firefoxview');
-      if (typeof message['url'] == "string") {
-        for (const tab of showTabs.reverse()) {
-          if (tab.isArticle == undefined || tab.active == true) {
-            browser.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: currentTab.id, active: message['active']});
-            return;
-          }
-        }
-      } else {
-        for (const tab of showTabs.reverse()) {
-          if (tab.isArticle == undefined || tab.active == true) {
-            for (const i in message['url']){
-              if (message['active'] == true){
-                if (i == 0){
-                  browser.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active'] });
+    browser.storage.sync.get({superDrag: _getDefault()}).then(result => {
+      const settings = result.superDrag;
+      if (settings.tabOpenPos === 'next') {
+        browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
+          const activeTab = tabs[0];
+          if (typeof message['url'] == "string") {
+            browser.tabs.create({index: activeTab.index + 1, url: message['url'], openerTabId: activeTab.id, active: message['active']});
+          } else {
+            for (var i in message['url']) {
+              if (message['active'] == true) {
+                if (i == 0) {
+                  browser.tabs.create({index: activeTab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: activeTab.id, active: message['active']});
                 } else {
-                  browser.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: false });
+                  browser.tabs.create({index: activeTab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: activeTab.id, active: false});
                 }
               } else {
-                browser.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active'] });
+                browser.tabs.create({index: activeTab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: activeTab.id, active: message['active']});
               }
             }
-            return;
           }
-        }
+        });
+      } else { // 'end'
+        browser.tabs.query({currentWindow: true}).then(tabs => {
+          let currentTab = tabs.find(tab => tab.active === true);
+          let showTabs = tabs.filter(tab => tab.url !== 'about:firefoxview');
+          if (typeof message['url'] == "string") {
+            for (const tab of showTabs.reverse()) {
+              if (tab.isArticle == undefined || tab.active == true) {
+                browser.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: currentTab.id, active: message['active']});
+                return;
+              }
+            }
+          } else {
+            for (const tab of showTabs.reverse()) {
+              if (tab.isArticle == undefined || tab.active == true) {
+                for (const i in message['url']) {
+                  if (message['active'] == true) {
+                    if (i == 0) {
+                      browser.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active']});
+                    } else {
+                      browser.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: false});
+                    }
+                  } else {
+                    browser.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active']});
+                  }
+                }
+                return;
+              }
+            }
+          }
+        });
       }
     });
   } else if (message['flag'] == 'download') {
     browser.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
-    },function(downloadId) {
-        console.log(downloadId);
+    }, function (downloadId) {
+      console.log(downloadId);
     });
   }
   sendResponse({status: 'ok'});

--- a/firefox/background-script.js
+++ b/firefox/background-script.js
@@ -20,6 +20,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
               }
             }
           }
+          sendResponse({status: 'ok'});
         });
       } else { // 'end'
         browser.tabs.query({currentWindow: true}).then(tabs => {
@@ -29,6 +30,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
             for (const tab of showTabs.reverse()) {
               if (tab.isArticle == undefined || tab.active == true) {
                 browser.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: currentTab.id, active: message['active']});
+                sendResponse({status: 'ok'});
                 return;
               }
             }
@@ -46,20 +48,25 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     browser.tabs.create({index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active']});
                   }
                 }
+                sendResponse({status: 'ok'});
                 return;
               }
             }
           }
+          sendResponse({status: 'ok'});
         });
       }
     });
+    return true; // Indicates async response
   } else if (message['flag'] == 'download') {
     browser.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
     }, function (downloadId) {
       console.log(downloadId);
+      sendResponse({status: 'ok'});
     });
+    return true; // Indicates async response
   }
   sendResponse({status: 'ok'});
 });

--- a/firefox/common.js
+++ b/firefox/common.js
@@ -8,6 +8,7 @@ function _getDefault() {
 		showNotice: true,
 		keyCode: "Escape",
 		openLinksOpenType: 1,
+		tabOpenPos: "end",
 
 		effect_text : 0,
 		open_type : [1, 1, 0, 1],

--- a/firefox/options.html
+++ b/firefox/options.html
@@ -36,6 +36,18 @@
     </div>
     <hr>
     <div>
+        <span id="tabOpenPos" style="font-size: 15px"></span>
+        <label style="font-size: 15px; margin-left: 10px;">
+            <input type="radio" id="tabOpenPosNext" name="tabOpenPos" value="next">
+            <span id="tabOpenPosNextLabel"></span>
+        </label>
+        <label style="font-size: 15px; margin-left: 10px;">
+            <input type="radio" id="tabOpenPosEnd" name="tabOpenPos" value="end">
+            <span id="tabOpenPosEndLabel"></span>
+        </label>
+    </div>
+    <hr>
+    <div>
         <span id="openLinksDesc" style="font-size: 15px"></span>
         <input id="keyCode" type="text" placeholder="event.key" style="width: 60px">
         <span id="openLinksDesc2" style="font-size: 15px"></span>

--- a/firefox/options.html
+++ b/firefox/options.html
@@ -37,14 +37,7 @@
     <hr>
     <div>
         <span id="tabOpenPos" style="font-size: 15px"></span>
-        <label style="font-size: 15px; margin-left: 10px;">
-            <input type="radio" id="tabOpenPosNext" name="tabOpenPos" value="next">
-            <span id="tabOpenPosNextLabel"></span>
-        </label>
-        <label style="font-size: 15px; margin-left: 10px;">
-            <input type="radio" id="tabOpenPosEnd" name="tabOpenPos" value="end">
-            <span id="tabOpenPosEndLabel"></span>
-        </label>
+        <select id="tabOpenPosSelect" style="font-size: 15px; margin-left: 10px;"></select>
     </div>
     <hr>
     <div>

--- a/firefox/options.js
+++ b/firefox/options.js
@@ -169,6 +169,13 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
             reader.readAsText(file);
         }, false);
 
+    document.querySelectorAll('input[name="tabOpenPos"]').forEach(elem => {
+        elem.addEventListener("change", function(event) {
+            superDrag.superDrag.tabOpenPos = event.target.value;
+            _save(superDrag.superDrag);
+        });
+    });
+
     document.getElementById('timeout').value = superDrag.superDrag.timeout;
     document.getElementById('keyCode').value = superDrag.superDrag.keyCode;
     for (i = 0; i < 3; i++) {
@@ -214,6 +221,16 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     document.getElementById("showNotice").checked = superDrag.superDrag.showNotice;
     document.getElementById("exportBtnLabel").innerText = browser.i18n.getMessage('export');
     document.getElementById("fileInputLabel").innerText = browser.i18n.getMessage('fileInput');
+
+    document.getElementById('tabOpenPos').innerHTML = browser.i18n.getMessage('tabOpenPos');
+    document.getElementById('tabOpenPosNextLabel').innerHTML = browser.i18n.getMessage('tabOpenPosNextLabel');
+    document.getElementById('tabOpenPosEndLabel').innerHTML = browser.i18n.getMessage('tabOpenPosEndLabel');
+
+    if (superDrag.superDrag.tabOpenPos === 'next') {
+        document.getElementById('tabOpenPosNext').checked = true;
+    } else {
+        document.getElementById('tabOpenPosEnd').checked = true;
+    }
 
     for (i = 0; i < 4; i++) {
         types = superDrag.superDrag.open_type;

--- a/firefox/options.js
+++ b/firefox/options.js
@@ -169,12 +169,11 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
             reader.readAsText(file);
         }, false);
 
-    document.querySelectorAll('input[name="tabOpenPos"]').forEach(elem => {
-        elem.addEventListener("change", function(event) {
-            superDrag.superDrag.tabOpenPos = event.target.value;
+    document.getElementById("tabOpenPosSelect").addEventListener(
+        "change", function () {
+            superDrag.superDrag.tabOpenPos = this.value;
             _save(superDrag.superDrag);
-        });
-    });
+        }, false);
 
     document.getElementById('timeout').value = superDrag.superDrag.timeout;
     document.getElementById('keyCode').value = superDrag.superDrag.keyCode;
@@ -223,14 +222,14 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     document.getElementById("fileInputLabel").innerText = browser.i18n.getMessage('fileInput');
 
     document.getElementById('tabOpenPos').innerHTML = browser.i18n.getMessage('tabOpenPos');
-    document.getElementById('tabOpenPosNextLabel').innerHTML = browser.i18n.getMessage('tabOpenPosNextLabel');
-    document.getElementById('tabOpenPosEndLabel').innerHTML = browser.i18n.getMessage('tabOpenPosEndLabel');
-
-    if (superDrag.superDrag.tabOpenPos === 'next') {
-        document.getElementById('tabOpenPosNext').checked = true;
-    } else {
-        document.getElementById('tabOpenPosEnd').checked = true;
+    
+    // Initialize tab open position dropdown
+    const tabOpenPosSelect = document.getElementById("tabOpenPosSelect");
+    if (!tabOpenPosSelect.options.length) {
+        tabOpenPosSelect.add(new Option(browser.i18n.getMessage('tabOpenPosNext'), 'next', false));
+        tabOpenPosSelect.add(new Option(browser.i18n.getMessage('tabOpenPosEnd'), 'end', false));
     }
+    tabOpenPosSelect.value = superDrag.superDrag.tabOpenPos;
 
     for (i = 0; i < 4; i++) {
         types = superDrag.superDrag.open_type;


### PR DESCRIPTION
 本次提交引入了一个新设置，允许用户选择新标签页的打开位置。

  用户现在可以在以下两种方式中选择：
  - 在当前活动标签页旁边打开
  - 在标签页列表末尾打开（当前的默认行为）

  此改动使得在 b4b71c1 中引入的行为，可以通过扩展的选项页面进行配置。