### PR TITLE
feat: 新增标签页打开位置配置选项

### DIFF
--- a/chromium/common.js
+++ b/chromium/common.js
@@ -8,6 +8,7 @@ function _getDefault() {
 		showNotice: true,
 		keyCode: "Escape",
 		openLinksOpenType: 1,
+		tabOpenPosition: 0,
 
 		effect_text : 0,
 		open_type : [1, 1, 0, 1],
@@ -29,6 +30,7 @@ function _getDefault() {
 var direction_val = ["↖ ↙ ↗ ↘", "↑ ↓ ← →"];
 var _effect_text = ["四面八方", "上下", "左右"];
 var _open_type = ["前台", "后台"];
+var _tab_open_position = ["右侧打开", "末尾打开"];
 var _text_type = ["搜索", "复制", "生成二维码"];
 var _effect_link = ["四面八方", "上下", "左右"];
 var _link_type = ["打开链接", "复制链接", "复制链接文本", "搜索链接文本", "生成二维码"];

--- a/chromium/eventpage.js
+++ b/chromium/eventpage.js
@@ -1,48 +1,52 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message['flag'] == 'openTable') {
+    // 使用后台脚本原始的、正确的方式获取设置，并提供默认值
     chrome.storage.sync.get({superDrag: {tabOpenPosition: 0}}, function(result) {
-      const tabOpenPosition = result.superDrag.tabOpenPosition || 0;
-      chrome.tabs.query({currentWindow: true}, tabs => {
-        // 查找参考标签页：优先找有 openerTabId 的，否则找当前激活的
-        const referenceTab = tabs.find(tab => tab.hasOwnProperty("openerTabId")) || 
-                             tabs.find(tab => tab.active);
-        
-        if (!referenceTab) {
-          console.error('未找到参考标签页');
-          return;
-        }
+      const tabOpenPosition = (result.superDrag && result.superDrag.tabOpenPosition) || 0;
+      
+      // 核心修正：直接使用 sender.tab 作为最可靠的参考
+      const referenceTab = sender.tab;
+      
+      if (!referenceTab) {
+        console.error('SuperDrag: 无法获取源标签页.');
+        return;
+      }
 
-        if (typeof message['url'] == "string") {
-          // 单个URL处理
-          const index = tabOpenPosition === 0 ? referenceTab.index + 1 : undefined;
-          chrome.tabs.create({
-            index: index, 
-            url: message['url'], 
-            openerTabId: referenceTab.id, 
-            active: message['active']
-          }).catch(err => console.error('创建标签页失败:', err));
-        } else {
-          // 多个URL处理
-          for (let i = 0; i < message['url'].length; i++) {
-            const index = tabOpenPosition === 0 ? referenceTab.index + i + 1 : undefined;
-            const active = message['active'] ? (i === 0) : message['active'];
-            
-            chrome.tabs.create({
-              index: index,
-              url: message['url'][i]['url'],
-              openerTabId: referenceTab.id,
-              active: active
-            }).catch(err => console.error('创建标签页失败:', err));
-          }
+      const createInRight = tabOpenPosition === 0;
+
+      if (typeof message['url'] === "string") {
+        // 单个URL处理
+        let createData = {
+          url: message['url'],
+          active: message['active'],
+          openerTabId: referenceTab.id
+        };
+        if (createInRight) {
+          createData.index = referenceTab.index + 1;
         }
-      });
+        chrome.tabs.create(createData);
+
+      } else if (Array.isArray(message['url'])) {
+        // 多个URL处理
+        message['url'].forEach((item, i) => {
+          let createData = {
+            url: item.url,
+            active: message['active'] ? (i === 0) : false,
+            openerTabId: referenceTab.id
+          };
+          if (createInRight) {
+            createData.index = referenceTab.index + 1 + i;
+          }
+          chrome.tabs.create(createData);
+        });
+      }
     });
+    // 异步响应需要返回 true
+    return true;
   } else if (message['flag'] == 'download') {
     chrome.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
-    },function(downloadId) {
-        console.log(downloadId);
     });
   }
   sendResponse({status: 'ok'});

--- a/chromium/eventpage.js
+++ b/chromium/eventpage.js
@@ -1,33 +1,41 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message['flag'] == 'openTable') {
-    chrome.tabs.query({currentWindow: true}, tabs => {
-      // console.log(tabs)
-      // console.log(message);
-      if (typeof message['url'] == "string") {
-        for (const tab of tabs.reverse()) {
-          if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
-            chrome.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: tab.id, active: message['active']});
-            return;
+    chrome.storage.sync.get({superDrag: {tabOpenPosition: 0}}, function(result) {
+      const tabOpenPosition = result.superDrag.tabOpenPosition || 0;
+      chrome.tabs.query({currentWindow: true}, tabs => {
+        // 查找参考标签页：优先找有 openerTabId 的，否则找当前激活的
+        const referenceTab = tabs.find(tab => tab.hasOwnProperty("openerTabId")) || 
+                             tabs.find(tab => tab.active);
+        
+        if (!referenceTab) {
+          console.error('未找到参考标签页');
+          return;
+        }
+
+        if (typeof message['url'] == "string") {
+          // 单个URL处理
+          const index = tabOpenPosition === 0 ? referenceTab.index + 1 : undefined;
+          chrome.tabs.create({
+            index: index, 
+            url: message['url'], 
+            openerTabId: referenceTab.id, 
+            active: message['active']
+          }).catch(err => console.error('创建标签页失败:', err));
+        } else {
+          // 多个URL处理
+          for (let i = 0; i < message['url'].length; i++) {
+            const index = tabOpenPosition === 0 ? referenceTab.index + i + 1 : undefined;
+            const active = message['active'] ? (i === 0) : message['active'];
+            
+            chrome.tabs.create({
+              index: index,
+              url: message['url'][i]['url'],
+              openerTabId: referenceTab.id,
+              active: active
+            }).catch(err => console.error('创建标签页失败:', err));
           }
         }
-      } else {
-        for (const tab of tabs.reverse()) {
-          if (tab.hasOwnProperty("openerTabId") || tab.active == true) {
-            for (const i in message['url']){
-              if (message['active'] == true){
-                if (i == 0){
-                  chrome.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active'] });
-                } else {
-                  chrome.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: false });
-                }
-              } else {
-                chrome.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: tab.id, active: message['active'] });
-              }
-            }
-            return;
-          }
-        }
-      }
+      });
     });
   } else if (message['flag'] == 'download') {
     chrome.downloads.download({

--- a/chromium/options.html
+++ b/chromium/options.html
@@ -48,6 +48,12 @@
     </div>
     <hr>
     <div>
+        <span id="tabOpenPositionDesc" style="font-size: 15px"></span>
+        <select id="tabOpenPosition"></select>
+        <small id="tabOpenPositionPrompt" style="font-size: 14px; color: grey"></small>
+    </div>
+    <hr>
+    <div>
         <button id="exportBtn" style="display: none;"></button>
         <label id="exportBtnLabel" for="exportBtn" style=" display: inline-block; padding: 8px 16px; background-color: #516F9C; color: white; font-size: 14px; border-radius: 4px; cursor: pointer; text-align: center; user-select: none;"></label>
         <input type="file" id="fileInput" accept=".json" style="display: none;">

--- a/chromium/options.js
+++ b/chromium/options.js
@@ -41,6 +41,10 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
         "change", function () {
             _save_open_type_open_links(this, superDrag);
         }, false);
+    document.getElementById("tabOpenPosition").addEventListener(
+        "change", function () {
+            _save_tab_open_position(this, superDrag);
+        }, false);
     for (i = 0; i < 4; i++) {
         document.getElementById("text_type_" + i).addEventListener(
             "change", function () {
@@ -199,6 +203,8 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     document.getElementById('openLinksDesc2').innerHTML = chrome.i18n.getMessage('openLinksDesc2');
     document.getElementById('openLinksDesc3').innerHTML = chrome.i18n.getMessage('openLinksDesc3');
     document.getElementById('openLinksPrompt').innerHTML = chrome.i18n.getMessage('openLinksPrompt');
+    document.getElementById('tabOpenPositionDesc').innerHTML = chrome.i18n.getMessage('tabOpenPositionDesc');
+    document.getElementById('tabOpenPositionPrompt').innerHTML = chrome.i18n.getMessage('tabOpenPositionPrompt');
     document.getElementById('effect_text_prompt').innerHTML = chrome.i18n.getMessage('effectPrompt');
     document.getElementById('effect_link_prompt').innerHTML = chrome.i18n.getMessage('effectPrompt');
     document.getElementById('effect_img_prompt').innerHTML = chrome.i18n.getMessage('effectPrompt');
@@ -236,6 +242,9 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
 
     _open_links_select = _init_open_type_open_links()
     _open_links_select.selectedIndex = superDrag.superDrag.openLinksOpenType;
+
+    _tab_open_position_select = _init_tab_open_position()
+    _tab_open_position_select.selectedIndex = superDrag.superDrag.tabOpenPosition;
 
     for (i = 0; i < 4; i++) {
         types = superDrag.superDrag.text_type;
@@ -512,6 +521,16 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
         return _select;
     }
 
+    function _init_tab_open_position() {
+        const _select = document.getElementById("tabOpenPosition");
+        if (!_select.options.length) {
+            for (let i = 0; i < _tab_open_position.length; i++) {
+                _select.add(new Option(_tab_open_position[i], i, false));
+            }
+        }
+        return _select;
+    }
+
     function _init_text_type(_id) {
         const _select = document.getElementById("text_type_" + _id);
         if (!_select.options.length) {
@@ -647,6 +666,12 @@ chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     function _save_open_type_open_links(_select, superDrag) {// select
         const _v = _select.options[_select.selectedIndex].value;
         superDrag.superDrag.openLinksOpenType = Number(_v);
+        _save(superDrag.superDrag)
+    }
+
+    function _save_tab_open_position(_select, superDrag) {// select
+        const _v = _select.options[_select.selectedIndex].value;
+        superDrag.superDrag.tabOpenPosition = Number(_v);
         _save(superDrag.superDrag)
     }
 

--- a/firefox/background-script.js
+++ b/firefox/background-script.js
@@ -1,48 +1,52 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message['flag'] == 'openTable') {
+    // 使用后台脚本原始的、正确的方式获取设置，并提供默认值
     chrome.storage.sync.get({superDrag: {tabOpenPosition: 0}}, function(result) {
-      const tabOpenPosition = result.superDrag.tabOpenPosition || 0;
-      chrome.tabs.query({currentWindow: true}, tabs => {
-        // 查找参考标签页：优先找有 openerTabId 的，否则找当前激活的
-        const referenceTab = tabs.find(tab => tab.hasOwnProperty("openerTabId")) || 
-                             tabs.find(tab => tab.active);
-        
-        if (!referenceTab) {
-          console.error('未找到参考标签页');
-          return;
-        }
+      const tabOpenPosition = (result.superDrag && result.superDrag.tabOpenPosition) || 0;
+      
+      // 核心修正：直接使用 sender.tab 作为最可靠的参考
+      const referenceTab = sender.tab;
+      
+      if (!referenceTab) {
+        console.error('SuperDrag: 无法获取源标签页.');
+        return;
+      }
 
-        if (typeof message['url'] == "string") {
-          // 单个URL处理
-          const index = tabOpenPosition === 0 ? referenceTab.index + 1 : undefined;
-          chrome.tabs.create({
-            index: index, 
-            url: message['url'], 
-            openerTabId: referenceTab.id, 
-            active: message['active']
-          }).catch(err => console.error('创建标签页失败:', err));
-        } else {
-          // 多个URL处理
-          for (let i = 0; i < message['url'].length; i++) {
-            const index = tabOpenPosition === 0 ? referenceTab.index + i + 1 : undefined;
-            const active = message['active'] ? (i === 0) : message['active'];
-            
-            chrome.tabs.create({
-              index: index,
-              url: message['url'][i]['url'],
-              openerTabId: referenceTab.id,
-              active: active
-            }).catch(err => console.error('创建标签页失败:', err));
-          }
+      const createInRight = tabOpenPosition === 0;
+
+      if (typeof message['url'] === "string") {
+        // 单个URL处理
+        let createData = {
+          url: message['url'],
+          active: message['active'],
+          openerTabId: referenceTab.id
+        };
+        if (createInRight) {
+          createData.index = referenceTab.index + 1;
         }
-      });
+        chrome.tabs.create(createData);
+
+      } else if (Array.isArray(message['url'])) {
+        // 多个URL处理
+        message['url'].forEach((item, i) => {
+          let createData = {
+            url: item.url,
+            active: message['active'] ? (i === 0) : false,
+            openerTabId: referenceTab.id
+          };
+          if (createInRight) {
+            createData.index = referenceTab.index + 1 + i;
+          }
+          chrome.tabs.create(createData);
+        });
+      }
     });
+    // 异步响应需要返回 true
+    return true;
   } else if (message['flag'] == 'download') {
     chrome.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
-    },function(downloadId) {
-        console.log(downloadId);
     });
   }
   sendResponse({status: 'ok'});

--- a/firefox/background-script.js
+++ b/firefox/background-script.js
@@ -1,38 +1,44 @@
-browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message['flag'] == 'openTable') {
-    browser.tabs.query({currentWindow: true}, tabs => {
-      // console.log(tabs)
-      // console.log(message);
-      let currentTab = tabs.find(tab => tab.active === true);
-      let showTabs = tabs.filter(tab => tab.url !== 'about:firefoxview');
-      if (typeof message['url'] == "string") {
-        for (const tab of showTabs.reverse()) {
-          if (tab.isArticle == undefined || tab.active == true) {
-            browser.tabs.create({index: tab.index + 1, url: message['url'], openerTabId: currentTab.id, active: message['active']});
-            return;
+    chrome.storage.sync.get({superDrag: {tabOpenPosition: 0}}, function(result) {
+      const tabOpenPosition = result.superDrag.tabOpenPosition || 0;
+      chrome.tabs.query({currentWindow: true}, tabs => {
+        // 查找参考标签页：优先找有 openerTabId 的，否则找当前激活的
+        const referenceTab = tabs.find(tab => tab.hasOwnProperty("openerTabId")) || 
+                             tabs.find(tab => tab.active);
+        
+        if (!referenceTab) {
+          console.error('未找到参考标签页');
+          return;
+        }
+
+        if (typeof message['url'] == "string") {
+          // 单个URL处理
+          const index = tabOpenPosition === 0 ? referenceTab.index + 1 : undefined;
+          chrome.tabs.create({
+            index: index, 
+            url: message['url'], 
+            openerTabId: referenceTab.id, 
+            active: message['active']
+          }).catch(err => console.error('创建标签页失败:', err));
+        } else {
+          // 多个URL处理
+          for (let i = 0; i < message['url'].length; i++) {
+            const index = tabOpenPosition === 0 ? referenceTab.index + i + 1 : undefined;
+            const active = message['active'] ? (i === 0) : message['active'];
+            
+            chrome.tabs.create({
+              index: index,
+              url: message['url'][i]['url'],
+              openerTabId: referenceTab.id,
+              active: active
+            }).catch(err => console.error('创建标签页失败:', err));
           }
         }
-      } else {
-        for (const tab of showTabs.reverse()) {
-          if (tab.isArticle == undefined || tab.active == true) {
-            for (const i in message['url']){
-              if (message['active'] == true){
-                if (i == 0){
-                  browser.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active'] });
-                } else {
-                  browser.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: false });
-                }
-              } else {
-                browser.tabs.create({ index: tab.index + Number(i) + 1, url: message['url'][i]['url'], openerTabId: currentTab.id, active: message['active'] });
-              }
-            }
-            return;
-          }
-        }
-      }
+      });
     });
   } else if (message['flag'] == 'download') {
-    browser.downloads.download({
+    chrome.downloads.download({
       url: message['url'],
       saveAs: message['saveAs']
     },function(downloadId) {

--- a/firefox/common.js
+++ b/firefox/common.js
@@ -8,6 +8,7 @@ function _getDefault() {
 		showNotice: true,
 		keyCode: "Escape",
 		openLinksOpenType: 1,
+		tabOpenPosition: 0,
 
 		effect_text : 0,
 		open_type : [1, 1, 0, 1],
@@ -29,6 +30,7 @@ function _getDefault() {
 var direction_val = ["↖ ↙ ↗ ↘", "↑ ↓ ← →"];
 var _effect_text = ["四面八方", "上下", "左右"];
 var _open_type = ["前台", "后台"];
+var _tab_open_position = ["右侧打开", "末尾打开"];
 var _text_type = ["搜索", "复制", "生成二维码"];
 var _effect_link = ["四面八方", "上下", "左右"];
 var _link_type = ["打开链接", "复制链接", "复制链接文本", "搜索链接文本", "生成二维码"];

--- a/firefox/options.html
+++ b/firefox/options.html
@@ -48,6 +48,12 @@
     </div>
     <hr>
     <div>
+        <span id="tabOpenPositionDesc" style="font-size: 15px"></span>
+        <select id="tabOpenPosition"></select>
+        <small id="tabOpenPositionPrompt" style="font-size: 14px; color: grey"></small>
+    </div>
+    <hr>
+    <div>
         <button id="exportBtn" style="display: none;"></button>
         <label id="exportBtnLabel" for="exportBtn" style=" display: inline-block; padding: 8px 16px; background-color: #516F9C; color: white; font-size: 14px; border-radius: 4px; cursor: pointer; text-align: center; user-select: none;"></label>
         <input type="file" id="fileInput" accept=".json" style="display: none;">

--- a/firefox/options.js
+++ b/firefox/options.js
@@ -1,4 +1,4 @@
-browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
+chrome.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     let types;
     let _s;
     let i;
@@ -40,6 +40,10 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     document.getElementById("openLinks").addEventListener(
         "change", function () {
             _save_open_type_open_links(this, superDrag);
+        }, false);
+    document.getElementById("tabOpenPosition").addEventListener(
+        "change", function () {
+            _save_tab_open_position(this, superDrag);
         }, false);
     for (i = 0; i < 4; i++) {
         document.getElementById("text_type_" + i).addEventListener(
@@ -139,7 +143,7 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
             const jsonData = JSON.stringify(superDrag.superDrag);
             const blob = new Blob([jsonData], { type: 'application/json' });
             const url = URL.createObjectURL(blob);
-            browser.runtime.sendMessage({
+            chrome.runtime.sendMessage({
                 'url': url,
                 'flag': 'download',
                 'saveAs': superDrag.superDrag.saveAs
@@ -157,12 +161,12 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
                     const importedData = JSON.parse(content);
                     superDrag.superDrag = importedData
                     _save(superDrag.superDrag);
-                    document.getElementById("fileInputTips").innerHTML = browser.i18n.getMessage('fileInputSuccessful');
+                    document.getElementById("fileInputTips").innerHTML = chrome.i18n.getMessage('fileInputSuccessful');
                     setTimeout(function() {
                         location.reload();
                     }, 2000); // 2000 毫秒 = 2 秒
                 } catch (err) {
-                    document.getElementById("fileInputTips").innerHTML = browser.i18n.getMessage('fileInputFailed');
+                    document.getElementById("fileInputTips").innerHTML = chrome.i18n.getMessage('fileInputFailed');
                 }
             };
 
@@ -186,34 +190,36 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     }
     _s.selectedIndex = superDrag.superDrag.effect_img;
     _load_effect_img(superDrag.superDrag.effect_img, superDrag);
-    document.getElementById('common').innerHTML = browser.i18n.getMessage('common');
-    document.getElementById('direction').innerHTML = browser.i18n.getMessage('direction');
-    document.getElementById('direction_des').innerHTML = browser.i18n.getMessage('direction_des');
-    document.getElementById('enableAlt_text').innerHTML = browser.i18n.getMessage('enableAlt_text');
-    document.getElementById('timeout_des').innerHTML = browser.i18n.getMessage('timeout_des');
-    document.getElementById('timeout_des2').innerHTML = browser.i18n.getMessage('timeout_des2');
-    document.getElementById('firstEventDesc').innerHTML = browser.i18n.getMessage('firstEventDesc');
-    document.getElementById('saveAsDesc').innerHTML = browser.i18n.getMessage('saveAsDesc');
-    document.getElementById('showNoticeDesc').innerHTML = browser.i18n.getMessage('showNoticeDesc');
-    document.getElementById('openLinksDesc').innerHTML = browser.i18n.getMessage('openLinksDesc');
-    document.getElementById('openLinksDesc2').innerHTML = browser.i18n.getMessage('openLinksDesc2');
-    document.getElementById('openLinksDesc3').innerHTML = browser.i18n.getMessage('openLinksDesc3');
-    document.getElementById('openLinksPrompt').innerHTML = browser.i18n.getMessage('openLinksPrompt');
-    document.getElementById('effect_text_prompt').innerHTML = browser.i18n.getMessage('effectPrompt');
-    document.getElementById('effect_link_prompt').innerHTML = browser.i18n.getMessage('effectPrompt');
-    document.getElementById('effect_img_prompt').innerHTML = browser.i18n.getMessage('effectPrompt');
-    document.getElementById('fieldtext0').innerHTML = browser.i18n.getMessage('fieldtext0');
-    document.getElementById('fieldlink0').innerHTML = browser.i18n.getMessage('fieldlink0');
-    document.getElementById('fieldimg0').innerHTML = browser.i18n.getMessage('fieldimg0');
-    document.getElementById('searchUrlDescription').innerHTML = browser.i18n.getMessage('searchUrlDescription');
-    document.getElementById('linkSearchUrlDescription').innerHTML = browser.i18n.getMessage('searchUrlDescription');
-    document.getElementById('imgSearchUrlDescription').innerHTML = browser.i18n.getMessage('searchUrlDescription');
+    document.getElementById('common').innerHTML = chrome.i18n.getMessage('common');
+    document.getElementById('direction').innerHTML = chrome.i18n.getMessage('direction');
+    document.getElementById('direction_des').innerHTML = chrome.i18n.getMessage('direction_des');
+    document.getElementById('enableAlt_text').innerHTML = chrome.i18n.getMessage('enableAlt_text');
+    document.getElementById('timeout_des').innerHTML = chrome.i18n.getMessage('timeout_des');
+    document.getElementById('timeout_des2').innerHTML = chrome.i18n.getMessage('timeout_des2');
+    document.getElementById('firstEventDesc').innerHTML = chrome.i18n.getMessage('firstEventDesc');
+    document.getElementById('saveAsDesc').innerHTML = chrome.i18n.getMessage('saveAsDesc');
+    document.getElementById('showNoticeDesc').innerHTML = chrome.i18n.getMessage('showNoticeDesc');
+    document.getElementById('openLinksDesc').innerHTML = chrome.i18n.getMessage('openLinksDesc');
+    document.getElementById('openLinksDesc2').innerHTML = chrome.i18n.getMessage('openLinksDesc2');
+    document.getElementById('openLinksDesc3').innerHTML = chrome.i18n.getMessage('openLinksDesc3');
+    document.getElementById('openLinksPrompt').innerHTML = chrome.i18n.getMessage('openLinksPrompt');
+    document.getElementById('tabOpenPositionDesc').innerHTML = chrome.i18n.getMessage('tabOpenPositionDesc');
+    document.getElementById('tabOpenPositionPrompt').innerHTML = chrome.i18n.getMessage('tabOpenPositionPrompt');
+    document.getElementById('effect_text_prompt').innerHTML = chrome.i18n.getMessage('effectPrompt');
+    document.getElementById('effect_link_prompt').innerHTML = chrome.i18n.getMessage('effectPrompt');
+    document.getElementById('effect_img_prompt').innerHTML = chrome.i18n.getMessage('effectPrompt');
+    document.getElementById('fieldtext0').innerHTML = chrome.i18n.getMessage('fieldtext0');
+    document.getElementById('fieldlink0').innerHTML = chrome.i18n.getMessage('fieldlink0');
+    document.getElementById('fieldimg0').innerHTML = chrome.i18n.getMessage('fieldimg0');
+    document.getElementById('searchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
+    document.getElementById('linkSearchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
+    document.getElementById('imgSearchUrlDescription').innerHTML = chrome.i18n.getMessage('searchUrlDescription');
     document.getElementById("enableAlt").checked = superDrag.superDrag.enableAlt;
     document.getElementById("firstEvent").checked = superDrag.superDrag.firstEvent;
     document.getElementById("saveAs").checked = superDrag.superDrag.saveAs;
     document.getElementById("showNotice").checked = superDrag.superDrag.showNotice;
-    document.getElementById("exportBtnLabel").innerText = browser.i18n.getMessage('export');
-    document.getElementById("fileInputLabel").innerText = browser.i18n.getMessage('fileInput');
+    document.getElementById("exportBtnLabel").innerText = chrome.i18n.getMessage('export');
+    document.getElementById("fileInputLabel").innerText = chrome.i18n.getMessage('fileInput');
 
     for (i = 0; i < 4; i++) {
         types = superDrag.superDrag.open_type;
@@ -236,6 +242,9 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
 
     _open_links_select = _init_open_type_open_links()
     _open_links_select.selectedIndex = superDrag.superDrag.openLinksOpenType;
+
+    _tab_open_position_select = _init_tab_open_position()
+    _tab_open_position_select.selectedIndex = superDrag.superDrag.tabOpenPosition;
 
     for (i = 0; i < 4; i++) {
         types = superDrag.superDrag.text_type;
@@ -512,6 +521,16 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
         return _select;
     }
 
+    function _init_tab_open_position() {
+        const _select = document.getElementById("tabOpenPosition");
+        if (!_select.options.length) {
+            for (let i = 0; i < _tab_open_position.length; i++) {
+                _select.add(new Option(_tab_open_position[i], i, false));
+            }
+        }
+        return _select;
+    }
+
     function _init_text_type(_id) {
         const _select = document.getElementById("text_type_" + _id);
         if (!_select.options.length) {
@@ -548,7 +567,7 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
             for (let i = 0; i < _build_in_seach_engines.length; i++) {
                 _select.add(new Option(_build_in_seach_engines[i].name, i, false));
             }
-            _select.add(new Option(browser.i18n.getMessage("custom_search"), -1,
+            _select.add(new Option(chrome.i18n.getMessage("custom_search"), -1,
                 false, false));
         }
         return _select;
@@ -560,7 +579,7 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
             for (let i = 0; i < _build_in_seach_engines.length; i++) {
                 _select.add(new Option(_build_in_seach_engines[i].name, i, false));
             }
-            _select.add(new Option(browser.i18n.getMessage("custom_search"), -1,
+            _select.add(new Option(chrome.i18n.getMessage("custom_search"), -1,
                 false, false));
         }
         return _select;
@@ -572,7 +591,7 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
             for (let i = 0; i < _build_in_seach_engines_for_img.length; i++) {
                 _select.add(new Option(_build_in_seach_engines_for_img[i].name, i, false));
             }
-            _select.add(new Option(browser.i18n.getMessage("custom_search"), -1,
+            _select.add(new Option(chrome.i18n.getMessage("custom_search"), -1,
                 false, false));
         }
         return _select;
@@ -647,6 +666,12 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     function _save_open_type_open_links(_select, superDrag) {// select
         const _v = _select.options[_select.selectedIndex].value;
         superDrag.superDrag.openLinksOpenType = Number(_v);
+        _save(superDrag.superDrag)
+    }
+
+    function _save_tab_open_position(_select, superDrag) {// select
+        const _v = _select.options[_select.selectedIndex].value;
+        superDrag.superDrag.tabOpenPosition = Number(_v);
         _save(superDrag.superDrag)
     }
 
@@ -787,7 +812,7 @@ browser.storage.sync.get({superDrag: _getDefault()}, function (superDrag) {
     }
 
     function _save(superDrag) {
-        browser.storage.sync.set({superDrag: superDrag}, function () {
+        chrome.storage.sync.set({superDrag: superDrag}, function () {
         });
     }
 })


### PR DESCRIPTION
为 Chrome 和 Firefox 版本添加了标签页打开位置的配置选项，允许用户选择在当前标签页右侧或末尾打开新标签页。

主要改动：
- **common.js**: 添加  配置
- **options.html**: 添加配置下拉框
- **options.js**: 实现配置保存和读取
- **eventpage.js/background-script.js**: 根据配置创建标签页